### PR TITLE
[cla] Some documentation references 'desktop.apps'

### DIFF
--- a/desktop/dojotoolkit/lucid/apps/KatanaIDE.js
+++ b/desktop/dojotoolkit/lucid/apps/KatanaIDE.js
@@ -22,4 +22,4 @@ dojo.requireLocalization("lucid.apps.KatanaIDE", "ide");
 dojo.require("lucid.apps.KatanaIDE._base");
 dojo.require("lucid.apps.KatanaIDE.CodeTextArea");
 dojo.require("lucid.apps.KatanaIDE.EditorLite");
-lucid.addDojoCss("desktop/apps/KatanaIDE/codeEditor.css");
+lucid.addDojoCss("lucid/apps/KatanaIDE/codeEditor.css");

--- a/documentation/dev/howto/custom-widgets.txt
+++ b/documentation/dev/howto/custom-widgets.txt
@@ -35,7 +35,7 @@ _base.js
 
    dojo.provide("lucid.apps.MyApp._base");
 
-   dojo.declare("lucid.apps.MyApp", desktop.apps._App, {
+   dojo.declare("lucid.apps.MyApp", lucid.apps._App, {
        init: function(args) {
            this.win = new lucid.widget.Window({
                title: "My App",

--- a/documentation/dev/howto/translations.txt
+++ b/documentation/dev/howto/translations.txt
@@ -14,7 +14,7 @@ they are (in bold):
 
   - dojotoolkit/
 
-    - desktop/
+    - lucid/
 
       - apps/
 
@@ -80,7 +80,7 @@ for countries, but hey...
 
 Translating an application
 --------------------------
-If you open one of these files, say ``desktop/apps/Contacts/nls/Contacts.js``
+If you open one of these files, say ``lucid/apps/Contacts/nls/Contacts.js``
 for exemple, you'll see this
 
 .. code-block:: javascript
@@ -102,7 +102,7 @@ language folder. What you'll see there are key/value pairs. You need to translat
 the right side which are the values.
 
 For example, this is the french translation, located in 
-``desktop/apps/Contacts/nls/fr/``
+``lucid/apps/Contacts/nls/fr/``
 
 .. code-block:: javascript
 

--- a/documentation/dev/intro/application-structure.txt
+++ b/documentation/dev/intro/application-structure.txt
@@ -5,7 +5,7 @@ Application Structure
 =====================
 Applications are Dojo modules
 =============================
-Lucid applications are essentially dojo modules. They live in the ``lucid.apps`` namespace. The name of the module in this namespace is known as the application's system name, or sysname. All applications extend the ``desktop.apps._App`` class, which contains some bootstrap code and self-management functions.
+Lucid applications are essentially dojo modules. They live in the ``lucid.apps`` namespace. The name of the module in this namespace is known as the application's system name, or sysname. All applications extend the ``lucid.apps._App`` class, which contains some bootstrap code and self-management functions.
 
 Metadata
 ========

--- a/documentation/dev/intro/application-tutorial.txt
+++ b/documentation/dev/intro/application-tutorial.txt
@@ -10,7 +10,7 @@ This tutorial will assume that you know how to use Dojo's widget system. If you 
 
 .. _Dojo's documentation: http://dojotoolkit.org/documentation/
 
-You can use Katana IDE to write your application, or you may use your favorite text editor. If you use a text editor, you have to create the app in the IDE first, and then open ``/desktop/dojotoolkit/desktop/apps/YourApp.js`` in the text editor.
+You can use Katana IDE to write your application, or you may use your favorite text editor. If you use a text editor, you have to create the app in the IDE first, and then open ``/desktop/dojotoolkit/lucid/apps/YourApp.js`` in the text editor.
 
 
 In this tutorial, we will be writing a simple contact manager app. You will see how easy it is to make such a useful application. From the IDE, click on the 'New' button, and enter in 'MyContacts' as the System name, and 'My Contacts' as the displayed name. System names cannot contain spaces, should start with a letter, and should be camel-cased. Displayed names, however, can contain anything. The IDE will then create your application, and give you the skeleton below.
@@ -19,7 +19,7 @@ In this tutorial, we will be writing a simple contact manager app. You will see 
 
     dojo.provide("lucid.apps.MyContacts");
     
-    dojo.declare("lucid.apps.MyContacts", desktop.apps._App, {
+    dojo.declare("lucid.apps.MyContacts", lucid.apps._App, {
         init: function(args) {
             /*Startup code goes here*/
         }
@@ -194,7 +194,7 @@ Here's the full application's code:
     dojo.require("dijit.form.Button");
     lucid.addDojoCss("dojox/grid/resources/Grid.css");
 
-    dojo.declare("lucid.apps.MyContacts", desktop.apps._App, {
+    dojo.declare("lucid.apps.MyContacts", lucid.apps._App, {
         init: function(args) {
             this.windows = [];
             var win = new lucid.widget.Window({


### PR DESCRIPTION
Some of the documentation (and a CSS reference in KatanaIDE) refers to the 'desktop.apps' namespace, which is also confusing in context.

Update the following files to 'lucid.apps':
- desktop/dojotoolkit/lucid/apps/KatanaIDE.js (addDojoCss call)
- documentation/dev/howto/custom-widgets.txt
- documentation/dev/howto/translations.txt
- documentation/dev/intro/application-structure.txt
- documentation/dev/intro/application-tutorial.txt
